### PR TITLE
Fix API URL quoting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ npm i review-code-ai
 Usage: review-code-ai [options]
 
 Options:
-  -g, --gitlab-api-url <string>       GitLab API URL (default: " https://gitlab.com/api/v4")
+  -g, --gitlab-api-url <string>       GitLab API URL (default: "https://gitlab.com/api/v4")
   -t, --gitlab-access-token <string>  GitLab Access Token
   -o, --openai-api-url <string>       OpenAI API URL (default: "https://api.openai.com/v1")
   -a, --openai-access-token <string>  OpenAI Access Token


### PR DESCRIPTION
## Summary
- fix quoting for GitLab API URL in options list

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: E403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684afce10824832ebc346fb452d00bee