### PR TITLE
Fix rate limiter logic and add tests

### DIFF
--- a/src/utils/__tests__/rate-limiter.test.ts
+++ b/src/utils/__tests__/rate-limiter.test.ts
@@ -1,0 +1,33 @@
+import { RateLimiter } from '../rate-limiter';
+
+describe('RateLimiter', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(0);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('throttles when the limit is exceeded', async () => {
+    const limiter = new RateLimiter(2);
+
+    const start = Date.now();
+    await limiter.acquire();
+    await limiter.acquire();
+
+    const acquirePromise = limiter.acquire();
+
+    // Fast forward time to allow the queued request to proceed
+    jest.advanceTimersByTime(61000);
+    await acquirePromise;
+    const end = Date.now();
+
+    expect(end - start).toBeGreaterThanOrEqual(61000);
+    // After cleanup the queue should contain only the last request
+    expect((limiter as any).requests.length).toBe(1);
+
+    limiter.destroy();
+  });
+});

--- a/src/utils/rate-limiter.ts
+++ b/src/utils/rate-limiter.ts
@@ -22,14 +22,19 @@ export class RateLimiter {
       return;
     }
 
-    // Otherwise, calculate how long to wait
+    // Otherwise, calculate how long to wait before the oldest request expires
     const oldestRequest = this.requests[0];
-    const timeToWait = oneMinuteAgo - oldestRequest + 1000; // Add 1s buffer
+    const timeToWait = oldestRequest + 60000 - now + 1000; // Add 1s buffer
 
     if (timeToWait > 0) {
       await new Promise(resolve => setTimeout(resolve, timeToWait));
-      return this.acquire(); // Try again after waiting
     }
+
+    // Record the request after waiting
+    const afterWait = Date.now();
+    const afterOneMinuteAgo = afterWait - 60000;
+    this.requests = this.requests.filter(time => time > afterOneMinuteAgo);
+    this.requests.push(afterWait);
   }
 
   private cleanup() {


### PR DESCRIPTION
## Summary
- correct time to wait in rate limiter
- ensure a new timestamp is recorded after waiting
- add tests confirming the rate limiter throttles requests

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684afce3b1a0832eaf464696e14c0cf2