### PR TITLE
Fix custom model option format in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Options:
   -p, --project-id <number>           GitLab Project ID
   -m, --merge-request-id <string>     GitLab Merge Request ID
   -org, --organization-id <number>    organization ID
-  -c, ----custom-model <string>       Custom Model ID (default: "gpt-3.5-turbo")
+  -c, --custom-model <string>       Custom Model ID (default: "gpt-3.5-turbo")
   -mode, --mode <string>              Mode use OpenAI or Gemini (default: openai)
   -r, --rules-path <string>           Path to custom rules directory or file
   --no-default-rules                  Disable default rules


### PR DESCRIPTION
## Summary
- fix typo in custom model command line option in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684afe4c6d68832ea8f32ea7ddc1465f